### PR TITLE
Add wg-easy VPN stack for easy WireGuard setup and management

### DIFF
--- a/stacks/wg-easy/WG-EASY.md
+++ b/stacks/wg-easy/WG-EASY.md
@@ -1,0 +1,4 @@
+## Before proceeding with installation, make sure to do the following (or else everything will become a mess):
+- Edit the docker-compose.yml file, following the steps below:
+  - Replace all instances of <home-router-external-ip> with the actual IP address of your home router (e.g., 54.734.989.12)
+  - Replace <your_secure_password> with a (secure) password

--- a/stacks/wg-easy/docker-compose.yml
+++ b/stacks/wg-easy/docker-compose.yml
@@ -1,0 +1,26 @@
+# Make sure you set up port forwarding on your home router as follows:
+#    <home-router-external-ip>:51820 --> <rpi-running-vpn>:51820
+#    <home-router-external-ip>:51821 --> <rpi-running-vpn>:51821
+
+version: '3.8'
+
+services:
+  wg-easy:
+    image: weejewel/wg-easy
+    container_name: wg-easy
+    environment:
+      - WG_HOST=<home-router-external-ip>  # Replace with your home router's IP address
+      - PASSWORD=<your_secure_password>  # Replace with your secure password
+    ports:
+      - "51820:51820/udp"  # Port for the VPN connection
+      - "51821:51821/tcp"  # Port for the web UI
+    volumes:
+      - ./data:/etc/wireguard
+    restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    sysctls:
+      - net.ipv4.conf.all.src_valid_mark=1
+      - net.ipv4.ip_forward=1
+      - net.ipv6.conf.all.forwarding=1


### PR DESCRIPTION
## Add wg-easy VPN stack for easy WireGuard management

This pull request introduces a new stack, "wg-easy," to the ClusteredPi project. The stack utilizes the wg-easy Docker image to simplify the setup and management of a WireGuard VPN. Key features include:

- **docker-compose.yml**:
  - Sets up port forwarding for VPN and web UI.
  - Configures the wg-easy service with necessary environment variables.
  - Maps ports 51820 (UDP) for VPN and 51821 (TCP) for the web UI.
  - Includes system controls for network forwarding and valid marks.

- **WG-EASY.md**:
  - Provides pre-installation steps to ensure proper setup.
  - Instructions to replace placeholders with actual router IP and a secure password.

This stack aims to make WireGuard VPN setup and management straightforward and accessible for users, enhancing the overall functionality of the ClusteredPi project.